### PR TITLE
Add search form to popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -53,6 +53,28 @@
       gap: 10px;
     }
 
+    #searchForm {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      margin-top: 15px;
+    }
+
+    #queryInput {
+      padding: 8px;
+      border: 1px solid #00ffff;
+      border-radius: 4px;
+      background-color: #1e1e1e;
+      color: #ffffff;
+      width: 100%;
+    }
+
+    #searchTips {
+      margin-top: 10px;
+      font-size: 12px;
+      text-align: left;
+    }
+
     .powered-by {
       margin-top: 20px;
       margin-bottom: 20px;
@@ -85,6 +107,17 @@
     <button id="searchGoogle">Search on Google</button>
     <button id="searchBehance">Search on Behance</button>
   </div>
+
+  <form id="searchForm">
+    <input type="text" id="queryInput" placeholder="Search query" />
+    <input type="hidden" id="platformInput" />
+    <label style="margin-top:10px;">
+      <input type="checkbox" id="quoteToggle" /> Use quotes
+    </label>
+    <button type="submit" style="margin-top:10px;">Search</button>
+  </form>
+
+  <div id="searchTips"></div>
 
   <div class="powered-by">
     Powered by <a href="http://www.absoluterecruiter.com" target="_blank">Absolute Recruiter</a>

--- a/popup.js
+++ b/popup.js
@@ -24,7 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
             }, (results) => {
                 if (results && results.length > 0 && results[0].result) {
                     // Set the selected text in the form input
-                    document.getElementById('queryInput').value = results[0].result;
+                    const queryField = document.getElementById('queryInput');
+                    queryField.value = results[0].result;
+                    queryField.focus();
 
                     // Save the selected platform
                     document.getElementById('platformInput').value = platform;


### PR DESCRIPTION
## Summary
- add a search form with query input, platform tracking and quote toggle
- style the new form and tips container
- focus the query field when populating selection

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687e354f25f483318685dfea3a3add5a