### PR TITLE
Add search URL helper and Jest tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ To add a new source to the extension, follow these steps:
 4. Update the event listener in the `popup.js` file to handle the new button's click event.
 
 Feel free to customize the extension to suit your specific needs and preferences. Please share and open source if you added more functionality!
+
+## Running Tests
+
+1. Install dependencies with `npm install`.
+2. Execute `npm test` to run the Jest test suite.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "multi-platform-search-extension",
+  "version": "1.0.0",
+  "description": "Multi-platform search extension",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,25 @@
+// Generate the search URL for a platform
+function getSearchUrl(platform, query) {
+  const q = encodeURIComponent(query);
+  switch (platform) {
+    case "Linkedin":
+      return `https://www.linkedin.com/search/results/people/?keywords=${q}`;
+    case "Github":
+      return `https://github.com/search?type=Users&q=${q}`;
+    case "MobyGames":
+      return `https://www.mobygames.com/search/quick?q=${q}`;
+    case "ArtStation":
+      return `https://www.artstation.com/search/artists?sort_by=followers&query=${q}`;
+    case "Google":
+      return `https://www.google.com/search?q=${q}`;
+    case "Behance":
+      return `https://www.behance.net/search/users?search=${q}`;
+    default:
+      return "";
+  }
+}
+
+if (typeof document !== 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
     // Platform button elements
     const searchLinkedinButton = document.getElementById('searchLinkedin');
@@ -43,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
         return window.getSelection().toString();
     }
 
+
     // Function to handle the search form submission
     document.getElementById('searchForm').addEventListener('submit', (event) => {
         event.preventDefault(); // Prevent form submission
@@ -57,20 +80,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Perform the search based on the platform
-        let url;
-        if (platform === 'Linkedin') {
-            url = 'https://www.linkedin.com/search/results/people/?keywords=' + encodeURIComponent(query);
-        } else if (platform === 'Github') {
-            url = 'https://github.com/search?type=Users&q=' + encodeURIComponent(query);
-        } else if (platform === 'MobyGames') {
-            url = 'https://www.mobygames.com/search/quick?q=' + encodeURIComponent(query);
-        } else if (platform === 'ArtStation') {
-            url = 'https://www.artstation.com/search/artists?sort_by=followers&query=' + encodeURIComponent(query);
-        } else if (platform === 'Google') {
-            url = 'https://www.google.com/search?q=' + encodeURIComponent(query);
-        } else if (platform === 'Behance') {
-            url = 'https://www.behance.net/search/users?search=' + encodeURIComponent(query);
-        }
+        const url = getSearchUrl(platform, query);
 
         // Open the search result in a new tab
         chrome.tabs.create({ url });
@@ -129,3 +139,9 @@ function showSearchTips(platform) {
   document.getElementById('searchTips').innerHTML = tips;
 }
 });
+}
+
+// Export for testing environments
+if (typeof module !== "undefined") {
+  module.exports = { getSearchUrl };
+}

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,0 +1,8 @@
+const { getSearchUrl } = require('./popup');
+
+describe('getSearchUrl', () => {
+  test('generates Google search URL', () => {
+    const url = getSearchUrl('Google', 'hello world');
+    expect(url).toBe('https://www.google.com/search?q=hello%20world');
+  });
+});


### PR DESCRIPTION
## Summary
- add `getSearchUrl` helper and expose via CommonJS export
- wrap popup code for Node testability
- create Jest test for Google URL
- add `package.json` and `.gitignore`
- document test steps

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e35a768808331a66c2bdab1cae6d0