### PR TITLE
Refactor search URL logic to use mapping

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,22 +1,16 @@
 // Generate the search URL for a platform
+const PLATFORM_URLS = {
+  Linkedin: 'https://www.linkedin.com/search/results/people/?keywords=',
+  Github: 'https://github.com/search?type=Users&q=',
+  MobyGames: 'https://www.mobygames.com/search/quick?q=',
+  ArtStation: 'https://www.artstation.com/search/artists?sort_by=followers&query=',
+  Google: 'https://www.google.com/search?q=',
+  Behance: 'https://www.behance.net/search/users?search=',
+};
+
 function getSearchUrl(platform, query) {
   const q = encodeURIComponent(query);
-  switch (platform) {
-    case "Linkedin":
-      return `https://www.linkedin.com/search/results/people/?keywords=${q}`;
-    case "Github":
-      return `https://github.com/search?type=Users&q=${q}`;
-    case "MobyGames":
-      return `https://www.mobygames.com/search/quick?q=${q}`;
-    case "ArtStation":
-      return `https://www.artstation.com/search/artists?sort_by=followers&query=${q}`;
-    case "Google":
-      return `https://www.google.com/search?q=${q}`;
-    case "Behance":
-      return `https://www.behance.net/search/users?search=${q}`;
-    default:
-      return "";
-  }
+  return PLATFORM_URLS[platform] ? `${PLATFORM_URLS[platform]}${q}` : '';
 }
 
 if (typeof document !== 'undefined') {
@@ -145,5 +139,5 @@ function showSearchTips(platform) {
 
 // Export for testing environments
 if (typeof module !== "undefined") {
-  module.exports = { getSearchUrl };
+  module.exports = { getSearchUrl, PLATFORM_URLS };
 }

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,8 +1,11 @@
-const { getSearchUrl } = require('./popup');
+const { getSearchUrl, PLATFORM_URLS } = require('./popup');
 
 describe('getSearchUrl', () => {
-  test('generates Google search URL', () => {
-    const url = getSearchUrl('Google', 'hello world');
-    expect(url).toBe('https://www.google.com/search?q=hello%20world');
-  });
+  const query = 'hello world';
+  for (const [platform, baseUrl] of Object.entries(PLATFORM_URLS)) {
+    test(`generates ${platform} search URL`, () => {
+      const url = getSearchUrl(platform, query);
+      expect(url).toBe(`${baseUrl}${encodeURIComponent(query)}`);
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- map platform names to search URL base strings in `popup.js`
- export the mapping for unit tests
- cover each platform in `popup.test.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e3dfe28d4833199d327965d9776a9