### PR TITLE
Share URL mapping between popup and background

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+importScripts('urls.js');
+
 const platforms = [
   { id: 'Linkedin', title: 'Search on LinkedIn' },
   { id: 'Github', title: 'Search on Github' },
@@ -6,26 +8,6 @@ const platforms = [
   { id: 'Google', title: 'Search on Google' },
   { id: 'Behance', title: 'Search on Behance' }
 ];
-
-function getSearchUrl(platform, query) {
-  const q = encodeURIComponent(query);
-  switch (platform) {
-    case 'Linkedin':
-      return `https://www.linkedin.com/search/results/people/?keywords=${q}`;
-    case 'Github':
-      return `https://github.com/search?type=Users&q=${q}`;
-    case 'MobyGames':
-      return `https://www.mobygames.com/search/quick?q=${q}`;
-    case 'ArtStation':
-      return `https://www.artstation.com/search/artists?sort_by=followers&query=${q}`;
-    case 'Google':
-      return `https://www.google.com/search?q=${q}`;
-    case 'Behance':
-      return `https://www.behance.net/search/users?search=${q}`;
-    default:
-      return '';
-  }
-}
 
 chrome.runtime.onInstalled.addListener(() => {
   platforms.forEach((platform) => {

--- a/popup.html
+++ b/popup.html
@@ -123,6 +123,7 @@
     Powered by <a href="http://www.absoluterecruiter.com" target="_blank">Absolute Recruiter</a>
   </div>
 
+  <script src="urls.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,16 +1,11 @@
-// Generate the search URL for a platform
-const PLATFORM_URLS = {
-  Linkedin: 'https://www.linkedin.com/search/results/people/?keywords=',
-  Github: 'https://github.com/search?type=Users&q=',
-  MobyGames: 'https://www.mobygames.com/search/quick?q=',
-  ArtStation: 'https://www.artstation.com/search/artists?sort_by=followers&query=',
-  Google: 'https://www.google.com/search?q=',
-  Behance: 'https://www.behance.net/search/users?search=',
-};
+// Access shared search utilities
+let PLATFORM_URLS;
+let getSearchUrl;
 
-function getSearchUrl(platform, query) {
-  const q = encodeURIComponent(query);
-  return PLATFORM_URLS[platform] ? `${PLATFORM_URLS[platform]}${q}` : '';
+if (typeof module !== 'undefined' && module.exports) {
+  ({ PLATFORM_URLS, getSearchUrl } = require('./urls'));
+} else {
+  ({ PLATFORM_URLS, getSearchUrl } = globalThis);
 }
 
 if (typeof document !== 'undefined') {
@@ -138,6 +133,6 @@ function showSearchTips(platform) {
 }
 
 // Export for testing environments
-if (typeof module !== "undefined") {
-  module.exports = { getSearchUrl, PLATFORM_URLS };
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = require('./urls');
 }

--- a/popup.test.js
+++ b/popup.test.js
@@ -1,4 +1,4 @@
-const { getSearchUrl, PLATFORM_URLS } = require('./popup');
+const { getSearchUrl, PLATFORM_URLS } = require('./urls');
 
 describe('getSearchUrl', () => {
   const query = 'hello world';

--- a/urls.js
+++ b/urls.js
@@ -1,0 +1,22 @@
+(function(global){
+const PLATFORM_URLS = {
+  Linkedin: 'https://www.linkedin.com/search/results/people/?keywords=',
+  Github: 'https://github.com/search?type=Users&q=',
+  MobyGames: 'https://www.mobygames.com/search/quick?q=',
+  ArtStation: 'https://www.artstation.com/search/artists?sort_by=followers&query=',
+  Google: 'https://www.google.com/search?q=',
+  Behance: 'https://www.behance.net/search/users?search=',
+};
+
+function getSearchUrl(platform, query){
+  const q = encodeURIComponent(query);
+  return PLATFORM_URLS[platform] ? `${PLATFORM_URLS[platform]}${q}` : '';
+}
+
+if (typeof module !== 'undefined' && module.exports){
+  module.exports = { PLATFORM_URLS, getSearchUrl };
+} else {
+  global.PLATFORM_URLS = PLATFORM_URLS;
+  global.getSearchUrl = getSearchUrl;
+}
+})(typeof globalThis !== 'undefined' ? globalThis : this);


### PR DESCRIPTION
## Summary
- add `urls.js` to centralize URL mappings and query helper
- load `urls.js` in the popup and background scripts
- remove duplicate switch logic in `background.js`
- update tests to import from the new module

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e431a3560833190567101da9d0f71