### PR TITLE
Use PLATFORM_URLS keys in context menu generation

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,19 +1,10 @@
 importScripts('urls.js');
 
-const platforms = [
-  { id: 'Linkedin', title: 'Search on LinkedIn' },
-  { id: 'Github', title: 'Search on Github' },
-  { id: 'MobyGames', title: 'Search on MobyGames' },
-  { id: 'ArtStation', title: 'Search on ArtStation' },
-  { id: 'Google', title: 'Search on Google' },
-  { id: 'Behance', title: 'Search on Behance' }
-];
-
 chrome.runtime.onInstalled.addListener(() => {
-  platforms.forEach((platform) => {
+  Object.keys(PLATFORM_URLS).forEach((platform) => {
     chrome.contextMenus.create({
-      id: platform.id,
-      title: `${platform.title} "%s"`,
+      id: platform,
+      title: `Search on ${platform} "%s"`,
       contexts: ['selection']
     });
   });


### PR DESCRIPTION
## Summary
- remove hard-coded list of platforms in `background.js`
- build context-menu entries dynamically from `PLATFORM_URLS`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e4590f06c8331a3295c8e04202fc5